### PR TITLE
Remove dependency on a package.json

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -1,10 +1,8 @@
 'use strict';
 
-var pkg = require('../package');
-
-var log = require('debug')(pkg.name + ':Query');
+var log = require('debug')('node-wmi:Query');
 console.log.bind(log);
-var error = require('debug')(pkg.name + ':Query');
+var error = require('debug')('node-wmi:Query');
 console.error.bind(error);
 
 var async = require('async');


### PR DESCRIPTION
Removing dependency on package.json file existing just to initialize the `debug` instances allows this package to be bundled in production applications, such as electron applications, without requiring this module to be excluded from the bundling process. Considering this package name will very likely _never_ change, there is no reason not to hardcode the string so this package can be bundled properly.